### PR TITLE
Image format

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject caribou/caribou-admin "0.13.0"
   :description "Generic admin tool for Caribou projects"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [caribou/caribou-frontend "0.12.37"]
+                 [caribou/caribou-frontend "0.13.0"]
                  [clj-time "0.4.4"]]
   :jvm-opts ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n"
              "-Djava.awt.headless=true"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject caribou/caribou-admin "0.12.22"
+(defproject caribou/caribou-admin "0.12.22-IMAGE-FORMAT"
   :description "Generic admin tool for Caribou projects"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [caribou/caribou-frontend "0.12.20"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject caribou/caribou-admin "0.13.14-IMAGE-TYPE"
+(defproject caribou/caribou-admin "0.13.4"
   :description "Generic admin tool for Caribou projects"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [caribou/caribou-frontend "0.13.4"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject caribou/caribou-admin "0.13.3"
+(defproject caribou/caribou-admin "0.13.14-IMAGE-TYPE"
   :description "Generic admin tool for Caribou projects"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [caribou/caribou-frontend "0.13.4"]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject caribou/caribou-admin "0.13.3"
   :description "Generic admin tool for Caribou projects"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [caribou/caribou-frontend "0.13.3"]
+                 [caribou/caribou-frontend "0.13.4"]
                  [clj-time "0.4.4"]]
   :jvm-opts ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n"
              "-Djava.awt.headless=true"

--- a/resources/public/_admin/js/modules/pages/content/backend.js
+++ b/resources/public/_admin/js/modules/pages/content/backend.js
@@ -3,7 +3,7 @@
 // Some core backend functionality such as managing the
 // access and retrieval of model information from the
 // server.  Most of these functions can be considered
-// utility functions and accessed via window.dtc.api.
+// utility functions and accessed via window.caribou.api.
 // --------------------------------------------------------
 
 (function (global) {

--- a/resources/public/_admin/js/modules/pages/content/editors/asset.js
+++ b/resources/public/_admin/js/modules/pages/content/editors/asset.js
@@ -104,6 +104,7 @@
       });
       $("#upload-button").click( function(e) {
         e.preventDefault();
+        global.caribou.status.clearMessages().render();
         self.upload(e);
       });
       $("#asset-search-button").click( function(e) {

--- a/resources/public/_admin/js/modules/pages/content/editors/asset.js
+++ b/resources/public/_admin/js/modules/pages/content/editors/asset.js
@@ -83,6 +83,9 @@
       $("#upload-asset").ajaxfileupload({
         action: self.api().routeFor("upload-asset"),
         valid_extensions: null,
+        onStart: function() {
+          global.caribou.status.clearMessages().render();
+        },
         onComplete: function(response) {
           try {
             self.value = response.state;

--- a/resources/public/_admin/js/modules/pages/content/editors/asset.js
+++ b/resources/public/_admin/js/modules/pages/content/editors/asset.js
@@ -86,6 +86,9 @@
         onComplete: function(response) {
           try {
             self.value = response.state;
+            if (response.warning) {
+              global.caribou.status.addInfoMessage(response.warning).render();
+            }
             if ( self.value['content-type'].indexOf("image") === 0 ) {
               $("#current-image").show().attr("src", self.value.path);
             } else {

--- a/resources/public/_admin/js/modules/pages/content/editors/stack.js
+++ b/resources/public/_admin/js/modules/pages/content/editors/stack.js
@@ -159,7 +159,9 @@
       } else {
         this.commandMenu().hide();
       }
-      //global.caribou.status.render().clearMessages();
+
+      global.caribou.status.clearMessages().render();
+
       element.trigger("didRender", this.activeEditor(), this);
       return this;
     },

--- a/resources/public/_admin/js/modules/pages/content/editors/stack.js
+++ b/resources/public/_admin/js/modules/pages/content/editors/stack.js
@@ -159,6 +159,9 @@
       } else {
         this.commandMenu().hide();
       }
+
+      global.caribou.status.clearMessages().render();
+
       element.trigger("didRender", this.activeEditor(), this);
       return this;
     },

--- a/resources/public/_admin/js/modules/pages/content/status.js
+++ b/resources/public/_admin/js/modules/pages/content/status.js
@@ -25,9 +25,11 @@
             });
             $( selector + ".alert-" + key ).find("ul").remove();
             if (list.length) {
-              $( selector + ".alert-" + key ).append("<ul>" + list + "</ul>").show();
+              $( selector + ".alert-" + key ).empty().append("<ul>" + list + "</ul>").show();
+            } else {
+              $( selector + ".alert-" + key ).hide();
             }
-          });
+          })
           return status;
         }
       };

--- a/src/caribou/admin/controllers/content/models.clj
+++ b/src/caribou/admin/controllers/content/models.clj
@@ -561,14 +561,14 @@
         warning (and
                  (= "image/jpeg" content-type)
                  (not (lichen/can-read-file? tempfile))
-                 (do (log/debug "warning about incompatible image") true)
-                 "Unreadable Image\nCaribou cannot resize this image, perhaps because of the file format.\nIs the image saved for web with an RGB color space?")
+                 "<p><h1>Unreadable Image</h1></p><p>Caribou cannot resize this image, perhaps because of the file format.\nIs the image saved for web with an RGB color space?</p>")
         response (if warning
                    {:state state
                     :warning warning}
                    {:state state})]
+    (when warning
+      (log/debug "warning about incompatible image"))
     (asset/put-asset tempfile asset)
-    (log/debug (str "content type: " content-type " response: " response))
     (json-response response)))
 
 (defn list-controllers-and-actions

--- a/src/caribou/admin/controllers/content/models.clj
+++ b/src/caribou/admin/controllers/content/models.clj
@@ -25,7 +25,8 @@
             [caribou.index :as index]
             [caribou.admin.helpers :as helpers]
             [caribou.admin.rights :as rights]
-            [caribou.admin.core :as admin]))
+            [caribou.admin.core :as admin]
+            [lichen.image :as lichen]))
 
 
 (defn inflate-request
@@ -546,17 +547,27 @@
 
 (defn upload-asset
   [request]
-  (let [params (:params request)
-        upload (get params "upload")
-        slug (slugify-filename (:filename upload))
+  (let [{{{:keys [content-type size filename tempfile]} "upload"} :params} request
+        slug (slugify-filename filename)
         asset (model/create
                :asset
                {:filename slug
-                :content-type (:content-type upload)
-                :size (:size upload)})
-        path (asset/asset-path asset)]
-    (asset/put-asset (:tempfile upload) asset)
-    (json-response {:state (assoc asset :path path)})))
+                :content-type content-type
+                :size size})
+        path (asset/asset-path asset)
+        state (assoc asset :path path)
+        warning (and
+                 (= "image/jpeg" content-type)
+                 (not (lichen/can-read-file? tempfile))
+                 (do (log/debug "warning about incompatible image") true)
+                 "Unreadable Image\nCaribou cannot resize this image, perhaps because of the file format.\nIs the image saved for web with an RGB color space?")
+        response (if warning
+                   {:state state
+                    :warning warning}
+                   {:state state})]
+    (asset/put-asset tempfile asset)
+    (log/debug (str "content type: " content-type " response: " response))
+    (json-response response)))
 
 (defn list-controllers-and-actions
   [request]


### PR DESCRIPTION
add warnings in admin when lichen cannot resize an image, also setting ground for warnings in the api results in general

even once we integrate cmyk jpeg support, the code will still work when people find yet another incompatible image format to use
